### PR TITLE
Add sample data fallback for failed MongoDB connection

### DIFF
--- a/server.js
+++ b/server.js
@@ -298,7 +298,24 @@ app.get('/api/v1/stocks', async (req, res) => {
 
   } catch (error) {
     console.error('Error fetching stocks from database:', error.message);
-    res.status(500).json({ error: 'Error fetching stocks' });
+
+    // Provide a small sample dataset when MongoDB isn't reachable so the
+    // frontend can continue to function during local development or when
+    // network access to the database is temporarily unavailable.
+    const sampleData = [
+      {
+        symbol: 'AAPL',
+        companyName: 'Apple Inc.',
+        price: 150,
+        simpleScore: 75,
+        sector: 'Technology'
+      }
+    ];
+
+    res.json({
+      data: sampleData,
+      pagination: { currentPage: 1, totalPages: 1, totalItems: sampleData.length }
+    });
   }
 });
 


### PR DESCRIPTION
## Summary
- provide fallback data in `/api/v1/stocks` when MongoDB fails

## Testing
- `npm install`
- `node server.js` *(fails to connect to MongoDB but server starts)*

------
https://chatgpt.com/codex/tasks/task_e_683fce50cf188322b91a2334a8f26916